### PR TITLE
Bump freedestkop runtime version to 19.08

### DIFF
--- a/io.gitlab.sdl_jstest.sdl2_jstest.json
+++ b/io.gitlab.sdl_jstest.sdl2_jstest.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.gitlab.sdl_jstest.sdl2_jstest",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "rename-appdata-file": "sdl2-jstest.appdata.xml",
     "finish-args": [

--- a/io.gitlab.sdl_jstest.sdl2_jstest.json
+++ b/io.gitlab.sdl_jstest.sdl2_jstest.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.gitlab.sdl_jstest.sdl2_jstest",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "rename-appdata-file": "sdl2-jstest.appdata.xml",
     "finish-args": [


### PR DESCRIPTION
Please run a test build first by commenting `bot, build`.
